### PR TITLE
[INFRA-6345] clean up mess with nutcracker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,4 +24,6 @@ HEALTHCHECK --interval=30s --timeout=30s --start-period=1s --retries=3 CMD bats 
 
 COPY --from=build-env /root/twemproxy/src/nutcracker /usr/sbin/nutcracker
 
+EXPOSE 11211
+
 CMD ["/usr/sbin/nutcracker", "-c", "/opt/nutcracker.yml"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,5 +25,6 @@ HEALTHCHECK --interval=30s --timeout=30s --start-period=1s --retries=3 CMD bats 
 COPY --from=build-env /root/twemproxy/src/nutcracker /usr/sbin/nutcracker
 
 EXPOSE 11211
+EXPOSE 22222
 
 CMD ["/usr/sbin/nutcracker", "-c", "/opt/nutcracker.yml"]

--- a/README.md
+++ b/README.md
@@ -326,8 +326,8 @@ DOCKER COMPOSE
 ==============
 
 ```
-BRANCH_NAME=INFRA-6245_simplify_container_builds docker-compose build --force-rm --no-cache --pull
-BRANCH_NAME=INFRA-6245_simplify_container_builds docker-compose up --detach --no-build
+BRANCH_NAME=v0.4.1-AF docker-compose build --force-rm --no-cache --pull
+BRANCH_NAME=v0.4.1-AF docker-compose up --detach --no-build
 ```
 
 SMOKE TESTS

--- a/README.md
+++ b/README.md
@@ -330,15 +330,15 @@ DOCKER COMPOSE
 ==============
 
 ```
-BRANCH_NAME=v0.4.1-AF docker-compose build --force-rm --no-cache --pull
-BRANCH_NAME=v0.4.1-AF docker-compose up --detach --no-build
+BRANCH_NAME=$(git describe --tags  --always --dirty --broken) docker-compose build --force-rm --no-cache --pull
+BRANCH_NAME=$(git describe --tags  --always --dirty --broken) docker-compose up --detach --no-build
 ```
 
 SMOKE TESTS
 ==========
 
 ```
-$ docker-compose exec elite-twemproxy bats /bats
+$ BRANCH_NAME=$(git describe --tags  --always --dirty --broken) docker-compose exec elite-twemproxy bats /bats
 1..2
 ok 1 [INFRA-6245] [nutcracker] Check nutcracker configuration
 ok 2 [INFRA-6245] [nutcracker] Check nutcracker version

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # twemproxy (nutcracker) [![Build Status](https://secure.travis-ci.org/twitter/twemproxy.png)](http://travis-ci.org/twitter/twemproxy)
 
+## Docker Hub
+
+* https://hub.docker.com/r/anchorfree/twemproxy/
+
 **twemproxy** (pronounced "two-em-proxy"), aka **nutcracker** is a fast and lightweight proxy for [memcached](http://www.memcached.org/) and [redis](http://redis.io/) protocol. It was built primarily to reduce the number of connections to the caching servers on the backend. This, together with protocol pipelining and sharding enables you to horizontally scale your distributed caching architecture.
 
 ## Build

--- a/bats/healthchecks.bats
+++ b/bats/healthchecks.bats
@@ -4,6 +4,12 @@
     /usr/sbin/nutcracker --test-conf -c /opt/nutcracker.yml
 }
 
+@test "[INFRA-6245] [nc] Test memcache port" {
+    run nc -zv localhost 11211
+    [ "$status" -eq 0 ]
+    [[ "$output"  == *"open"* ]]
+}
+
 @test "[INFRA-6245] [nutcracker] Check nutcracker version" {
     run /usr/sbin/nutcracker --version
     [ "$status" -eq 0 ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,8 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+    ports:
+      - "11211:11211"
     volumes:
       - type: bind
         source: ./nutcracker.yml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
       dockerfile: Dockerfile
     ports:
       - "11211:11211"
+      - "22222:22222"
     volumes:
       - type: bind
         source: ./nutcracker.yml


### PR DESCRIPTION
```
$ BRANCH_NAME=$(git describe --tags  --always --dirty --broken) docker-compose exec elite-twemproxy bats /bats
1..3
ok 1 [INFRA-6245] [nutcracker] Check nutcracker configuration
ok 2 [INFRA-6245] [nc] Test memcache port
ok 3 [INFRA-6245] [nutcracker] Check nutcracker version
```